### PR TITLE
Adds default purge CSS whitelist

### DIFF
--- a/build/webpack.mix.js
+++ b/build/webpack.mix.js
@@ -9,6 +9,11 @@ const postCssPlugins = [
 	require('tailwindcss')('./build/tailwind.config.js'),
 ];
 
+const postCssWhitelist = [
+	/^e-decoration-/,
+	/^e-trans-/,
+];
+
 if (mix.inProduction()) {
 	postCssPlugins.push(require('@fullhuman/postcss-purgecss')({
 		content: [
@@ -17,6 +22,7 @@ if (mix.inProduction()) {
 		],
 		// https://medium.com/@kyis/vue-tailwind-purgecss-the-right-way-c70d04461475
 		defaultExtractor: content => content.match(/[A-Za-z0-9-_/:]*[A-Za-z0-9-_/]+/g) || [],
+		whitelistPatterns: postCssWhitelist,
 	}));
 }
 


### PR DESCRIPTION
Because dynamic classes (e.g. .class-name-[variable]) aren't picked up, you can add whitelist patterns. Adding defaults makes it easier and improves the likelihood of consistency between devs.