### PR TITLE
Updates bootstrap for first-time setup

### DIFF
--- a/build/webpack.mix.js
+++ b/build/webpack.mix.js
@@ -44,6 +44,7 @@ mix
 		},
 		processCssUrls: false,
 		postCss: postCssPlugins,
+		clearConsole: !(process.env.NO_CLI_FLUSH),
 	})
 	.browserSync(browserSync)
 	.setPublicPath(paths.dest)

--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -130,7 +130,7 @@ fi
 export $(grep APP_KEY .env)
 if [ -z "$APP_KEY" ]; then
     echo -e "--> "$COLOUR_GREEN"Application initial setup"$COLOUR_RESET
-    echo -e $COLOUR_RED" Encryption key not generated"$COLOUR_RESET
+    echo -e $COLOUR_RED"Encryption key not generated"$COLOUR_RESET
     echo "Generating encryption key"
 
     ./scripts/console key:generate
@@ -141,8 +141,8 @@ fi
 # Generate frontend assets if they don't exist
 FILE_MIX_MANIFEST=public/mix-manifest.json
 if [ ! -f "$FILE_MIX_MANIFEST" ]; then
-    echo -e "--> "$COLOUR_GREEN"Frontend init"$COLOUR_RESET
-    echo -e $COLOUR_RED"Frontend assets not compilied!"$COLOUR_RESET
+    echo -e "--> "$COLOUR_GREEN"Frontend initial setup"$COLOUR_RESET
+    echo -e $COLOUR_RED"Frontend assets not compilied"$COLOUR_RESET
     echo "Compiling frontend assets"
 
     docker-compose run -e NO_CLI_FLUSH=true --rm build yarn run development --display=errors-only --no-progress

--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -127,11 +127,25 @@ else
 fi
 
 # If no application key, generate one
+export $(grep APP_KEY .env)
 if [ -z "$APP_KEY" ]; then
     echo -e "--> "$COLOUR_GREEN"Application initial setup"$COLOUR_RESET
-    echo "Generating Laravel encryption key"
+    echo -e $COLOUR_RED" Encryption key not generated"$COLOUR_RESET
+    echo "Generating encryption key"
 
     ./scripts/console key:generate
+
+    echo ""
+fi
+
+# Generate frontend assets if they don't exist
+FILE_MIX_MANIFEST=public/mix-manifest.json
+if [ ! -f "$FILE_MIX_MANIFEST" ]; then
+    echo -e "--> "$COLOUR_GREEN"Frontend init"$COLOUR_RESET
+    echo -e $COLOUR_RED"Frontend assets not compilied!"$COLOUR_RESET
+    echo "Compiling frontend assets"
+
+    docker-compose run -e NO_CLI_FLUSH=true --rm build yarn run development --display=errors-only --no-progress
 
     echo ""
 fi

--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -142,7 +142,7 @@ fi
 FILE_MIX_MANIFEST=public/mix-manifest.json
 if [ ! -f "$FILE_MIX_MANIFEST" ]; then
     echo -e "--> "$COLOUR_GREEN"Frontend initial setup"$COLOUR_RESET
-    echo -e $COLOUR_RED"Frontend assets not compilied"$COLOUR_RESET
+    echo -e $COLOUR_RED"Frontend assets not compiled"$COLOUR_RESET
     echo "Compiling frontend assets"
 
     docker-compose run -e NO_CLI_FLUSH=true --rm build yarn run development --display=errors-only --no-progress


### PR DESCRIPTION
- Added a check on **bootstrap** for the existence of the `mix-manifest`.
- Runs frontend build if check fails.
- **Bootstrap** frontend build doesn't flush the CLI output.
- Stops **bootstrap** regenerating the app key on every run.
- **Bootstrap** only generates key if it's missing from the `.env`.
- Adds environment var to Mix config to prevent it flushing the CLI output if it's present.