### PR TITLE
Bumps sentry version in Composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "fideloper/proxy": "^4.2",
         "laravel/framework": "^7.0",
         "laravel/tinker": "^2.0",
-        "sentry/sentry-laravel": "^1.6",
+        "sentry/sentry-laravel": "^1.7",
         "engageinteractive/laravel-frontend": "^3.0",
         "fruitcake/laravel-cors": "^1.0",
         "guzzlehttp/guzzle": "^6.3"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "52e4d8e246c49a938ffb767b2cf09741",
+    "content-hash": "e481ce6d2a665cb088b238cba2be0738",
     "packages": [
         {
             "name": "asm89/stack-cors",


### PR DESCRIPTION
Just making the minimum the latest for L7 support, quite trivial really.