### PR TITLE
Minimal error pages & fix to 500

### DIFF
--- a/resources/lang/en/errors.php
+++ b/resources/lang/en/errors.php
@@ -1,0 +1,98 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | 404: Page Not Found
+    |--------------------------------------------------------------------------
+    |
+    | Normally shows when theres an application error.
+    | Must use minimal layout.
+    |
+    */
+
+    'not_found' => [
+        'title' => 'Not Found',
+        'message' => 'It looks like the page you\'re looking for is no longer here.',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | 500: Internal Server Error
+    |--------------------------------------------------------------------------
+    |
+    | Normally shows when theres an application error.
+    | Must use minimal layout.
+    |
+    */
+
+    'server_error' => [
+        'title' => 'Server Error',
+        'message' => 'It looks like something has broken.',
+    ],
+
+
+    /*
+    |--------------------------------------------------------------------------
+    | 401: Unauthorized
+    |--------------------------------------------------------------------------
+    |
+    | 401 semantically means "unauthorised", the user does not have valid 
+    | authentication credentials for the target resource.
+    |
+    */
+
+    'unauthorised' => [
+        'title' => 'Unauthorised',
+        'message' => 'You\'re unauthorised to make this request.',
+    ],
+
+
+    /*
+    |--------------------------------------------------------------------------
+    | 403: Forbidden
+    |--------------------------------------------------------------------------
+    |
+    | The request contained valid data and was understood by the server, but the
+    | server is refusing action. This may be due to the user not having the
+    | necessary permissions for a resource or needing an account of some sort.
+    |
+    */
+
+    'forbidden' => [
+        'title' => 'Forbidden',
+        'message' => 'You\'re unauthorised to make this request.',
+    ],
+
+
+    /*
+    |--------------------------------------------------------------------------
+    | 419: Page Expired
+    |--------------------------------------------------------------------------
+    |
+    | Shown when a CSRF Token is missing or expired.
+    |
+    */
+
+    'page_expired' => [
+        'title' => 'Page Expired',
+        'message' => 'The page has expired.',
+    ],
+
+
+    /*
+    |--------------------------------------------------------------------------
+    | 429: Too Many Requests
+    |--------------------------------------------------------------------------
+    |
+    | The user has sent too many requests in a given amount of time.
+    | Intended for use with rate-limiting schemes.
+    |
+    */
+
+    'max_requests' => [
+        'title' => 'Too Many Requests',
+        'message' => 'There were too many requests to the server.',
+    ],
+];

--- a/resources/lang/en/errors.php
+++ b/resources/lang/en/errors.php
@@ -14,7 +14,8 @@ return [
 
     'not_found' => [
         'title' => 'Not Found',
-        'message' => 'It looks like the page you\'re looking for is no longer here.',
+        'message' => 'It looks like the page you’re looking for is no longer here.',
+        // 'cta' => false,
     ],
 
     /*
@@ -38,14 +39,14 @@ return [
     | 401: Unauthorized
     |--------------------------------------------------------------------------
     |
-    | 401 semantically means "unauthorised", the user does not have valid 
+    | 401 semantically means "unauthorised", the user does not have valid
     | authentication credentials for the target resource.
     |
     */
 
     'unauthorised' => [
         'title' => 'Unauthorised',
-        'message' => 'You\'re unauthorised to make this request.',
+        'message' => 'You’re unauthorised to make this request.',
     ],
 
 
@@ -62,7 +63,7 @@ return [
 
     'forbidden' => [
         'title' => 'Forbidden',
-        'message' => 'You\'re unauthorised to make this request.',
+        'message' => 'You’re unauthorised to make this request.',
     ],
 
 
@@ -94,5 +95,6 @@ return [
     'max_requests' => [
         'title' => 'Too Many Requests',
         'message' => 'There were too many requests to the server.',
+        'cta' => false,
     ],
 ];

--- a/resources/views/errors/401.blade.php
+++ b/resources/views/errors/401.blade.php
@@ -1,7 +1,1 @@
-@extends('layouts/minimal')
-
-@section('code', '401')
-
-@section('title', __('errors.unauthorised.title'))
-@section('heading', __('errors.unauthorised.title'))
-@section('message', __('errors.unauthorised.message'))
+@extends('layouts/error', __('errors.unauthorised'))

--- a/resources/views/errors/401.blade.php
+++ b/resources/views/errors/401.blade.php
@@ -1,0 +1,7 @@
+@extends('layouts/minimal')
+
+@section('code', '401')
+
+@section('title', __('errors.unauthorised.title'))
+@section('heading', __('errors.unauthorised.title'))
+@section('message', __('errors.unauthorised.message'))

--- a/resources/views/errors/403.blade.php
+++ b/resources/views/errors/403.blade.php
@@ -1,0 +1,7 @@
+@extends('layouts/minimal')
+
+@section('code', '403')
+
+@section('title', __('errors.forbidden.title'))
+@section('heading', __('errors.forbidden.title'))
+@section('message', __('errors.forbidden.message'))

--- a/resources/views/errors/403.blade.php
+++ b/resources/views/errors/403.blade.php
@@ -1,7 +1,1 @@
-@extends('layouts/minimal')
-
-@section('code', '403')
-
-@section('title', __('errors.forbidden.title'))
-@section('heading', __('errors.forbidden.title'))
-@section('message', __('errors.forbidden.message'))
+@extends('layouts/error', __('errors.forbidden'))

--- a/resources/views/errors/404.blade.php
+++ b/resources/views/errors/404.blade.php
@@ -1,16 +1,7 @@
-@extends('layouts/error', [
-	'page' => [
-		'title' => 'Page not found',
-		'description' => 'Sorry, the page you are looking for could not be found.',
-	],
-])
+@extends('layouts/minimal')
 
-@section('content')
+@section('code', '404')
 
-	<h1>Page Not Found</h1>
-
-	<p>It looks like the page you're looking for is no longer&nbsp;here.</p>
-
-	<p><a href="/">Return to the homepage</a></p>
-
-@endsection
+@section('title', __('errors.not_found.title'))
+@section('heading', __('errors.not_found.title'))
+@section('message', __('errors.not_found.message'))

--- a/resources/views/errors/404.blade.php
+++ b/resources/views/errors/404.blade.php
@@ -1,7 +1,1 @@
-@extends('layouts/minimal')
-
-@section('code', '404')
-
-@section('title', __('errors.not_found.title'))
-@section('heading', __('errors.not_found.title'))
-@section('message', __('errors.not_found.message'))
+@extends('layouts/error', __('errors.not_found'))

--- a/resources/views/errors/419.blade.php
+++ b/resources/views/errors/419.blade.php
@@ -1,0 +1,7 @@
+@extends('layouts/minimal')
+
+@section('code', '419')
+
+@section('title', __('errors.page_expired.title'))
+@section('heading', __('errors.page_expired.title'))
+@section('message', __('errors.page_expired.message'))

--- a/resources/views/errors/419.blade.php
+++ b/resources/views/errors/419.blade.php
@@ -1,7 +1,1 @@
-@extends('layouts/minimal')
-
-@section('code', '419')
-
-@section('title', __('errors.page_expired.title'))
-@section('heading', __('errors.page_expired.title'))
-@section('message', __('errors.page_expired.message'))
+@extends('layouts/error', __('errors.page_expired'))

--- a/resources/views/errors/429.blade.php
+++ b/resources/views/errors/429.blade.php
@@ -1,7 +1,1 @@
-@extends('layouts/minimal')
-
-@section('code', '429')
-
-@section('title', __('errors.max_requests.title'))
-@section('heading', __('errors.max_requests.title'))
-@section('message', __('errors.max_requests.message'))
+@extends('layouts/error', __('errors.max_requests'))

--- a/resources/views/errors/429.blade.php
+++ b/resources/views/errors/429.blade.php
@@ -1,0 +1,7 @@
+@extends('layouts/minimal')
+
+@section('code', '429')
+
+@section('title', __('errors.max_requests.title'))
+@section('heading', __('errors.max_requests.title'))
+@section('message', __('errors.max_requests.message'))

--- a/resources/views/errors/500.blade.php
+++ b/resources/views/errors/500.blade.php
@@ -1,7 +1,1 @@
-@extends('layouts/minimal')
-
-@section('code', '500')
-
-@section('title', __('errors.server_error.title'))
-@section('heading', __('errors.server_error.title'))
-@section('message', __('errors.server_error.message'))
+@extends('layouts/error', __('errors.server_error'))

--- a/resources/views/errors/500.blade.php
+++ b/resources/views/errors/500.blade.php
@@ -1,16 +1,7 @@
-@extends('layouts/error', [
-	'page' => [
-		'title' => 'Server error',
-		'description' => 'Sorry, it looks like something has broken.',
-	],
-])
+@extends('layouts/minimal')
 
-@section('content')
+@section('code', '500')
 
-	<h1>Server error</h1>
-
-	<p>Sorry, it looks like something has&nbsp;broken.</p>
-
-	<p><a href="/">Return to the homepage</a></p>
-
-@endsection
+@section('title', __('errors.server_error.title'))
+@section('heading', __('errors.server_error.title'))
+@section('message', __('errors.server_error.message'))

--- a/resources/views/layouts/error.blade.php
+++ b/resources/views/layouts/error.blade.php
@@ -1,9 +1,15 @@
-@extends('layouts/base')
+@extends('layouts/minimal')
 
-@section('app')
-	<main class="flex items-center min-h-screen p-3 text-center">
-		<div class="e-copy m-auto max-w-copy">
-			@yield('content')
-		</div>
-	</main>
+@section('title')
+	{{ $title }}
+@endsection
+
+@section('message')
+	<h1>{{ $heading ?? $title }}</h1>
+
+	<p>{{ $message }}</p>
+
+	@if ($cta ?? true)
+		<p><a href="{{ $url ?? '/' }}">{{ $cta ?? 'Return to the homepage' }}</a></p>
+	@endif
 @endsection

--- a/resources/views/layouts/minimal.blade.php
+++ b/resources/views/layouts/minimal.blade.php
@@ -1,28 +1,26 @@
-{{-- 
-    
-    |-----------------------------------------------------------------|
-    |  Warning: limited functionality should be added to this layout  |
-    |  It can render if the app is 'critically' impaired.             |
-    |-----------------------------------------------------------------|
+{{--
+
+	|-----------------------------------------------------------------|
+	|  Warning: limited functionality should be added to this layout  |
+	|  It can render if the app is 'critically' impaired.             |
+	|-----------------------------------------------------------------|
 
 --}}
-<!DOCTYPE html>
-<html lang="en">
-    <head>
-        <meta charset="utf-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1">
+<!doctype html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
 
-        <title>Error @yield('code') | @yield('title')</title>
-        
-        <link href="/compiled/css/app.css" rel="stylesheet">
-    </head>
-    <body>
-        <main class="flex items-center min-h-screen p-3 text-center">
-            <div class="e-copy m-auto max-w-copy">
-                <h1>@yield('heading')</h1>
-                <p>@yield('message')</p>
-                <p><a href="/">Return to the homepage</a></p>
-            </div>
-        </main>
-    </body>
+	<title>@yield('title')</title>
+
+	<link href="/compiled/css/app.css" rel="stylesheet">
+</head>
+<body>
+	<main class="flex items-center min-h-screen p-3 text-center">
+		<div class="e-copy m-auto max-w-copy">
+			@yield('message')
+		</div>
+	</main>
+</body>
 </html>

--- a/resources/views/layouts/minimal.blade.php
+++ b/resources/views/layouts/minimal.blade.php
@@ -1,0 +1,28 @@
+{{-- 
+    
+    |-----------------------------------------------------------------|
+    |  Warning: limited functionality should be added to this layout  |
+    |  It can render if the app is 'critically' impaired.             |
+    |-----------------------------------------------------------------|
+
+--}}
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+
+        <title>Error @yield('code') | @yield('title')</title>
+        
+        <link href="/compiled/css/app.css" rel="stylesheet">
+    </head>
+    <body>
+        <main class="flex items-center min-h-screen p-3 text-center">
+            <div class="e-copy m-auto max-w-copy">
+                <h1>@yield('heading')</h1>
+                <p>@yield('message')</p>
+                <p><a href="/">Return to the homepage</a></p>
+            </div>
+        </main>
+    </body>
+</html>


### PR DESCRIPTION
## Perspective
We have an issue currently where the **500 error** doesn't work, because it's relying on application functionality that requires the app runtime to be booted and functional ... so it just falls over, and the user doesn't see an error.

## Summary

1. Adds **minimal layout** — able to render when the app is impaired, and is lightweight — no requirement for meta, etc.
2. Updates **404**, and **500** errors to use new minimal layout — _(404 could use another layout, but probably best to use minimal by default)._
3. Adds **401** error — shows on unauthorised API requests.
4. Adds **403** error — shows on forbidden HTTP requests.
5. Adds **419** error — shows on CSRF failure or missing token.
6. Adds **429** error — shows when a request is rate-limited.

## To do
Need to add these error pages to `/frontend` display list, but may as well wait for the other branch to get merged in first.

## Checks
✅ Application is functional.
⚠️ No changes made to build systems, or backend code.