### PR TITLE
Adds error pages to /templates index

### DIFF
--- a/resources/views/templates/errors/404.blade.php
+++ b/resources/views/templates/errors/404.blade.php
@@ -1,3 +1,3 @@
-{{-- @description Shows on a page not found --}}
+{{-- @description Page Not Found --}}
 
 @extends('errors/404')

--- a/resources/views/templates/errors/419.blade.php
+++ b/resources/views/templates/errors/419.blade.php
@@ -1,0 +1,3 @@
+{{-- @description Page Expired --}}
+
+@extends('errors/419')

--- a/resources/views/templates/errors/429.blade.php
+++ b/resources/views/templates/errors/429.blade.php
@@ -1,0 +1,3 @@
+{{-- @description Too Many Requests --}}
+
+@extends('errors/429')

--- a/resources/views/templates/errors/500.blade.php
+++ b/resources/views/templates/errors/500.blade.php
@@ -1,3 +1,3 @@
-{{-- @description Shows on a page error --}}
+{{-- @description Server Error --}}
 
 @extends('errors/500')


### PR DESCRIPTION
Not much to this really. Adding the error pages to the `/templates` index page.

Opted to not add `401` or `403` as those wouldn't usually show unless theres an action to trigger it. Best not to confuse people by adding them to the list. `404`, `419`, `429`, and `500` have the potential to always show.

Added the following descriptions next to each:

- 404 (Page Not Found)
- 419 (Page Expired)
- 429 (Too Many Requests)
- 500 (Server Error)