### PR TITLE
Removes nested disabled rule

### DIFF
--- a/resources/assets/scss/core/_document.scss
+++ b/resources/assets/scss/core/_document.scss
@@ -15,8 +15,7 @@ body {
 	}
 }
 
-[disabled],
-[disabled] * {
+[disabled] {
 	@apply opacity-25 shadow-none cursor-not-allowed select-none;
 }
 


### PR DESCRIPTION
Typically the way we build forms, the form becomes disabled, as does the button inside the form. This results in the button's opacity becoming .0625.