### PR TITLE
Updates default grid classes

### DIFF
--- a/resources/assets/scss/block/_grid.scss
+++ b/resources/assets/scss/block/_grid.scss
@@ -1,25 +1,7 @@
 .e-grid {
-	@mixin macro($spacing) {
-		@apply -ml-#{$spacing};
-
-		&__item {
-			@apply mt-#{$spacing} pl-#{$spacing};
-		}
-	}
-	@include macro(5);
-	@apply flex flex-wrap;
+	@apply flex flex-wrap -ml-5;
 
 	&__item {
-		flex-shrink: 0;
-		position: relative;
-		width: 100%;
-	}
-
-	@screen md {
-		@include macro(6);
-	}
-
-	@screen xl {
-		@include macro(8);
+		@apply flex-shrink-0 relative w-full pl-5;
 	}
 }


### PR DESCRIPTION
Most of our projects still use these basic grid classes. However, we rarely change the gutters (they're usually 20px from mobile to desktop), and it'd be easier to add top margins where we need them, rather than removing when we don't.