### PR TITLE
Feature/docker updates

### DIFF
--- a/docker/local.app.php.ini
+++ b/docker/local.app.php.ini
@@ -1,3 +1,0 @@
-log_errors = On
-error_log = /dev/stderr
-memory_limit = 1024M

--- a/docker/local.docker-compose.yml
+++ b/docker/local.docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - "DBUS_SESSION_BUS_ADDRESS=/dev/null"
 
   db:
-    image: mariadb:10.3
+    image: mariadb:10.4
     restart: unless-stopped
     volumes:
       - ../docker/local.db.schema.sql:/docker-entrypoint-initdb.d/schema.sql:ro

--- a/docker/local.docker-compose.yml
+++ b/docker/local.docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
 
   web:
-    image: nginx:1.17
+    image: nginx:1.19
     restart: unless-stopped
     volumes:
       - ../:/var/www:delegated

--- a/docker/local.docker-compose.yml
+++ b/docker/local.docker-compose.yml
@@ -17,7 +17,6 @@ services:
     restart: unless-stopped
     volumes:
       - ../:/var/www:delegated
-      - ./local.app.php.ini:/usr/local/etc/php/php.ini:delegated
       - ~/.composer/docker-cache/:/root/.composer:cached
     depends_on:
       - db

--- a/docker/local.docker-compose.yml
+++ b/docker/local.docker-compose.yml
@@ -38,7 +38,7 @@ services:
       - 13306:3306
 
   build:
-    image: node:12
+    image: node:14
     volumes:
       - ../:/app:delegated
       - ~/.yarn/docker-cache/:/root/.yarn:cached

--- a/scripts/composer
+++ b/scripts/composer
@@ -9,4 +9,4 @@ set -e
 
 cd "$(dirname "$0")/.."
 
-docker-compose exec app composer $@
+docker-compose exec app php -d memory_limit=-1 /usr/bin/composer $@


### PR DESCRIPTION
**Simple updates which bumps software versions on containers.**

> `Node 12` to `Node 14` in line with LTS support.
> All FE functionality tested and is working as expected without problems.
> 
> Mariadb updated to be inline with RDS default version `10.4.x`
> 
> Nginx updated to latest version `1.19`

**Updates composer command to remove the memory limit, a problem cropping up at the moment.**

**Removes `php.ini` from docker folder. It's not doing anything!**