### PR TITLE
Adds lang attribute to html tag

### DIFF
--- a/resources/views/layouts/base.blade.php
+++ b/resources/views/layouts/base.blade.php
@@ -1,5 +1,5 @@
-<!doctype html>
-<html>
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
 <head>
 	@section('head')
 		@include('layouts/partials/meta', [

--- a/resources/views/layouts/minimal.blade.php
+++ b/resources/views/layouts/minimal.blade.php
@@ -6,8 +6,8 @@
 	|-----------------------------------------------------------------|
 
 --}}
-<!doctype html>
-<html>
+<!DOCTYPE html>
+<html lang="en">
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
Transplants the implementation from Laravel mainline: https://github.com/laravel/laravel/blob/8.x/resources/views/welcome.blade.php#L2

Statically `en` on minimal layouts for 500 pages and a critically impaired state (a trivial factor, but adding for consistency, and it's very unlikely these pages would get localised)