### PR TITLE
Adds temporary nesting fix for typography

### DIFF
--- a/resources/assets/css/block/copy.css
+++ b/resources/assets/css/block/copy.css
@@ -2,7 +2,9 @@
 	@apply max-w-prose;
 
 	> * {
-		@apply mt-em;
+		& {
+			@apply mt-em;
+		}
 
 		&:first-child {
 			@apply mt-0;
@@ -29,10 +31,14 @@
 
 	ol,
 	ul {
-		@apply mx-5;
+		& {
+			@apply mx-5;
+		}
 
 		> li {
-			@apply mt-em;
+			& {
+				@apply mt-em;
+			}
 
 			&:first-child {
 				@apply mt-0;


### PR DESCRIPTION
Currently, issue with postcss-nested and tailwind @apply rules. Can be fixed in TW 2.2+ using tailwindcss/nesting - however, JIT + watch tasks for some files currently broken, so can't roll with that right now.